### PR TITLE
Properly handle allow_extra_fields for fields

### DIFF
--- a/lollipop_jsonschema/jsonschema.py
+++ b/lollipop_jsonschema/jsonschema.py
@@ -110,8 +110,14 @@ def json_schema(schema):
         ]
         if required:
             js['required'] = required
-        if schema.allow_extra_fields is not None:
+        if schema.allow_extra_fields in [True, False]:
             js['additionalProperties'] = schema.allow_extra_fields
+        elif isinstance(schema.allow_extra_fields, lt.Field):
+            field_type = schema.allow_extra_fields.field_type
+            if isinstance(field_type, lt.Any):
+                js['additionalProperties'] = True
+            else:
+                js['additionalProperties'] = json_schema(field_type)
     elif isinstance(schema, lt.Dict):
         js['type'] = 'object'
         fixed_properties = schema.value_types \

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -113,24 +113,47 @@ class TestJsonSchema:
                                         'bar': lt.Optional(lt.Integer())}))
         assert 'required' not in result
 
-    def test_object_allow_extra_fields(self):
+    def test_object_no_allow_extra_fields(self):
         result = json_schema(lt.Object({
             'foo': lt.String(), 'bar': lt.Integer(),
         }))
 
         assert 'additionalProperties' not in result
 
+    def test_object_allow_extra_fields_true(self):
         result = json_schema(lt.Object({
             'foo': lt.String(), 'bar': lt.Integer(),
         }, allow_extra_fields=True))
 
         assert result['additionalProperties'] == True
 
+    def test_object_allow_extra_fields_any(self):
+        result = json_schema(lt.Object({
+            'foo': lt.String(), 'bar': lt.Integer(),
+        }, allow_extra_fields=lt.Any()))
+
+        assert result['additionalProperties'] == True
+
+    def test_object_allow_extra_fields_false(self):
         result = json_schema(lt.Object({
             'foo': lt.String(), 'bar': lt.Integer(),
         }, allow_extra_fields=False))
 
         assert result['additionalProperties'] == False
+
+    def test_object_allow_extra_fields_type(self):
+        result = json_schema(lt.Object({
+            'foo': lt.String(), 'bar': lt.Integer(),
+        }, allow_extra_fields=lt.Object({
+            'bar': lt.String(), 'foo': lt.Integer(),
+        })))
+
+        additional = result['additionalProperties']
+        assert additional['type'] == 'object'
+        assert additional['properties'] == {
+            'foo': {'type': 'integer'},
+            'bar': {'type': 'string'},
+        }
 
     def test_fixed_fields_dict_schema(self):
         result = json_schema(lt.Dict({'foo': lt.String(), 'bar': lt.Integer()}))


### PR DESCRIPTION
To properly transform a field into a value of the "additionalProperties"
parameter its type is used to create respective representation excluding
the Any type which is simply replaced by True.