### PR TITLE
Add straight implementation of definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "pypy"
 
 before_install:
+  - pip install -U setuptools
   - pip install -U pip
 
 install:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
+setuptools!=36.2.0
 pytest>=2.9
 tox>=1.5

--- a/lollipop_jsonschema/__init__.py
+++ b/lollipop_jsonschema/__init__.py
@@ -2,4 +2,5 @@ __version__ = '0.3'
 __author__ = 'Maxim Kulkin'
 
 
+from .jsonschema import References
 from .jsonschema import json_schema

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist=py26,py27,py33,py34,py35,py36,pypy
+
 [testenv]
 deps=
-  -rdev-requirements.txt
+  -r dev-requirements.txt
 commands=
   python setup.py test


### PR DESCRIPTION
The json_schema function got an additional positional argument which
allows to store and access references during composition of a scheme.

This change can break backward compatibility in case if the json_schema
function was used for schemas which contain TypeRef objects and which
are not considered as top level schemas.