### PR TITLE
Assorted improvements

### DIFF
--- a/lollipop_jsonschema/__init__.py
+++ b/lollipop_jsonschema/__init__.py
@@ -2,5 +2,4 @@ __version__ = '0.3'
 __author__ = 'Maxim Kulkin'
 
 
-from .jsonschema import References
 from .jsonschema import json_schema

--- a/lollipop_jsonschema/compat.py
+++ b/lollipop_jsonschema/compat.py
@@ -3,6 +3,8 @@ import sys
 PY2 = int(sys.version_info[0]) == 2
 
 if PY2:
+    itervalues = lambda d: d.itervalues()
     iteritems = lambda d: d.iteritems()
 else:
+    itervalues = lambda d: d.values()
     iteritems = lambda d: d.items()

--- a/lollipop_jsonschema/jsonschema.py
+++ b/lollipop_jsonschema/jsonschema.py
@@ -137,6 +137,12 @@ def is_load_schema(schema):
     return not has_modifier(schema, lt.DumpOnly)
 
 
+def is_type(schema, schema_type):
+    while isinstance(schema, (lt.Modifier, lr.TypeRef)):
+        schema = schema.inner_type
+    return isinstance(schema, schema_type)
+
+
 def _json_schema(schema, context, force_render=False):
     if schema in context.definitions and not force_render:
         return {'$ref': '#/definitions/' + context.definitions[schema].name}
@@ -277,7 +283,7 @@ def _json_schema(schema, context, force_render=False):
             field_type = schema.allow_extra_fields.field_type
             field_schema = _json_schema(field_type, context=context)
             if field_schema is not None:
-                if isinstance(field_type, lt.Any):
+                if is_type(field_type, lt.Any):
                     js['additionalProperties'] = True
                 else:
                     js['additionalProperties'] = field_schema

--- a/lollipop_jsonschema/jsonschema.py
+++ b/lollipop_jsonschema/jsonschema.py
@@ -108,6 +108,18 @@ def _count_schema_usages(schema, counts):
         _count_schema_usages(schema.inner_type, counts)
 
 
+def has_modifier(schema, modifier):
+    while isinstance(schema, (lt.Modifier, lr.TypeRef)):
+        if isinstance(schema, modifier):
+            return True
+        schema = schema.inner_type
+    return False
+
+
+def is_optional(schema):
+    return has_modifier(schema, lt.Optional)
+
+
 def _json_schema(schema, definitions, force_render=False):
     if schema in definitions and not force_render:
         return {'$ref': '#/definitions/' + definitions[schema].name}
@@ -215,7 +227,7 @@ def _json_schema(schema, definitions, force_render=False):
         required = [
             k
             for k, v in iteritems(schema.fields)
-            if not isinstance(v.field_type, lt.Optional)
+            if not is_optional(v.field_type)
         ]
         if required:
             js['required'] = required
@@ -238,8 +250,8 @@ def _json_schema(schema, definitions, force_render=False):
             js['properties'] = properties
         required = [
             k
-            for k, v in iteritems(fixed_properties)
-            if not isinstance(v, lt.Optional)
+            for k, v in iteritems(schema.value_types)
+            if not is_optional(v)
         ]
         if required:
             js['required'] = required

--- a/lollipop_jsonschema/jsonschema.py
+++ b/lollipop_jsonschema/jsonschema.py
@@ -154,7 +154,9 @@ def _json_schema(schema, context, force_render=False):
 
         if isinstance(schema, lt.Optional):
             default = schema.load_default()
-            if default:
+            if default is None:
+                js['default'] = None
+            elif default is not lt.MISSING:
                 js['default'] = schema.inner_type.dump(default)
         elif context.mode and (
                 (context.mode == 'dump' and not is_dump_schema(schema)) or

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -150,6 +150,13 @@ class TestJsonSchema:
 
         assert result['additionalProperties'] == True
 
+    def test_object_allow_extra_fields_any_with_modifiers(self):
+        result = json_schema(lt.Object({
+            'foo': lt.String(), 'bar': lt.Integer(),
+        }, allow_extra_fields=lt.Transform(lt.Any())))
+
+        assert result['additionalProperties'] == True
+
     def test_object_allow_extra_fields_false(self):
         result = json_schema(lt.Object({
             'foo': lt.String(), 'bar': lt.Integer(),

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -291,9 +291,11 @@ class TestJsonSchema:
         assert json_schema(lt.Constant('foo')) == {'const': 'foo'}
         assert json_schema(lt.Constant(123)) == {'const': 123}
 
-    def test_optional_schema_is_its_inner_type_schema(self):
-        assert json_schema(lt.Optional(lt.String())) == json_schema(lt.String())
-        assert json_schema(lt.Optional(lt.Integer())) == json_schema(lt.Integer())
+    def test_optional_schema_is_its_inner_type_schema_with_default_annotation(self):
+        assert json_schema(lt.Optional(lt.String())) == \
+            dict(json_schema(lt.String()), default=None)
+        assert json_schema(lt.Optional(lt.Integer())) == \
+            dict(json_schema(lt.Integer()), default=None)
 
     def test_optional_load_default_is_used_as_default(self):
         assert json_schema(lt.Optional(lt.String(), load_default='foo')) \
@@ -307,6 +309,10 @@ class TestJsonSchema:
         }), load_default=MyType('hello', 123)))
 
         assert result['default'] == {'foo': 'hello', 'bar': 123}
+
+    def test_optional_load_default_is_skipped_if_MISSING(self):
+        assert json_schema(lt.Optional(lt.String(), load_default=lt.MISSING)) \
+            == {'type': 'string'}
 
     def test_one_of_schema_with_sequence(self):
         t1 = lt.String()
@@ -408,7 +414,8 @@ class TestJsonSchema:
         assert 'definitions' in result
         assert result['definitions'] == {'MyString': json_schema(type1)}
         assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
-        assert result['properties']['bar'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar'] == \
+            {'$ref': '#/definitions/MyString', 'default': None}
         assert 'bar' not in result['required']
 
     def test_type_references(self):

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -2,7 +2,6 @@ import lollipop.type_registry as lr
 import lollipop.types as lt
 import lollipop.validators as lv
 from lollipop.utils import is_mapping
-from lollipop_jsonschema import References
 from lollipop_jsonschema import json_schema
 from lollipop_jsonschema.compat import iteritems
 import pytest
@@ -320,77 +319,183 @@ class TestJsonSchema:
         assert sorted_dicts([json_schema(FOO_SCHEMA), json_schema(BAR_SCHEMA)]) == \
             sorted_dicts(result['anyOf'])
 
-    def test_type_ref_cycled_array(self):
-        def assert_array(result):
-            assert 'array' == result['type']
-            items = result['items']['anyOf']
-            assert len(items) == 2
-            item0, item1 = items
-            assert 'string' == item0['type']
-            assert '$ref' in item1
+    def test_no_definitions_if_no_duplicate_types(self):
+        result = json_schema(lt.Object({'foo': lt.String(), 'bar': lt.String()}))
 
-        TYPES = lr.TypeRegistry()
-        MyType = TYPES.add(
-            'MyType',
-            lt.List(lt.OneOf([lt.String(), TYPES['MyType']])),
-        )
-
-        refs = References()
-        result = json_schema(MyType, refs=refs)
-
-        assert_array(result)
-
-        definitions = refs.definitions()
-        assert len(definitions) == 1
-        name, schema = list(definitions.items())[0]
-
-        assert '#/definitions/' + name == result['items']['anyOf'][1]['$ref']
-        assert_array(schema)
-
-    def test_type_ref(self):
-        TYPES = lr.TypeRegistry()
-
-        AType = TYPES.add('AType', lt.Object({
-            'a': lt.String(),
-            'c': TYPES['BType'],
-        }))
-        BType = TYPES.add('BType', lt.Object({
-            'b': lt.String(),
-        }))
-
-        refs = References()
-        result = json_schema(TYPES['AType'], refs=refs)
-        definitions = refs.definitions()
-
-        assert '$ref' in result
-        assert len(definitions) == 2
-        defs = sorted(
-            sorted(ref['properties'].keys())
-            for ref in definitions.values()
-        )
-        assert [['a', 'c'], ['b']] == defs
-
-    def test_cross_ref_top_level_schema(self):
-        TYPES = lr.TypeRegistry()
-
-        AType = TYPES.add('AType', lt.Object({
-            'a': lt.String(),
-            'c': TYPES['BType'],
-        }))
-        BType = TYPES.add('BType', lt.Object({
-            'b': lt.String(),
-        }))
-
-        result = json_schema(TYPES['AType'])
-        assert '$ref' in result
-        assert 'definitions' in result
-        assert len(result['definitions']) == 2
-        defs = sorted(
-            sorted(ref['properties'].keys())
-            for ref in result['definitions'].values()
-        )
-        assert [['a', 'c'], ['b']] == defs
-
-    def test_no_type_ref(self):
-        result = json_schema(lt.String())
         assert 'definitions' not in result
+
+    def test_duplicate_types_in_objects_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1, 'bar': type1}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar'] == {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_objects_extra_fields_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1}, allow_extra_fields=type1))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['additionalProperties'] == {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_lists_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1,
+                                        'bar': lt.List(type1)}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar']['items'] == \
+            {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_dicts_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1,
+                                        'bar': lt.Dict({'baz': type1})}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar']['properties']['baz'] == \
+            {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_dicts_default_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1,
+                                        'bar': lt.Dict(type1)}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar']['additionalProperties'] == \
+            {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_one_of_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1,
+                                        'bar': lt.OneOf([type1, lt.Integer()])}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar']['anyOf'][0] == \
+            {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_types_in_optional_are_extracted_to_definitions(self):
+        type1 = lt.String(name='MyString')
+        result = json_schema(lt.Object({'foo': type1,
+                                        'bar': lt.Optional(type1)}))
+
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar'] == {'$ref': '#/definitions/MyString'}
+        assert 'bar' not in result['required']
+
+    def test_type_references(self):
+        registry = lr.TypeRegistry()
+
+        type1 = lt.String(name='MyString')
+        type1_ref = registry.add('AString', type1)
+
+        assert json_schema(type1_ref) == json_schema(type1)
+
+    def test_duplicate_type_references_are_extracted_to_definitions(self):
+        registry = lr.TypeRegistry()
+
+        type1 = lt.String(name='MyString')
+        type1_ref = registry.add('AString', type1)
+
+        result = json_schema(lt.Object({'foo': type1_ref, 'bar': type1_ref}))
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar'] == {'$ref': '#/definitions/MyString'}
+
+    def test_duplicate_type_and_type_references_are_extracted_to_definitions(self):
+        registry = lr.TypeRegistry()
+
+        type1 = lt.String(name='MyString')
+        type1_ref = registry.add('AString', type1)
+
+        result = json_schema(lt.Object({'foo': type1, 'bar': type1_ref}))
+        assert 'definitions' in result
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+        assert result['properties']['foo'] == {'$ref': '#/definitions/MyString'}
+        assert result['properties']['bar'] == {'$ref': '#/definitions/MyString'}
+
+    def test_self_referencing_types(self):
+        registry = lr.TypeRegistry()
+        errors_type = registry.add('Errors', lt.Dict(
+            lt.OneOf([lt.String(), lt.List(lt.String()), registry['Errors']]),
+            name='Errors',
+        ))
+
+        result = json_schema(errors_type)
+
+        assert sorted(result.keys()) == sorted(['definitions', '$ref'])
+
+        assert 'Errors' in result['definitions']
+        errorsDef = result['definitions']['Errors']
+        assert errorsDef['title'] == 'Errors'
+        assert errorsDef['type'] == 'object'
+        assert errorsDef['additionalProperties'] == {
+            'anyOf': [
+                json_schema(lt.String()),
+                json_schema(lt.List(lt.String())),
+                {'$ref': '#/definitions/Errors'},
+            ]
+        }
+
+        assert result['$ref'] == '#/definitions/Errors'
+
+    def test_definition_name_sanitization(self):
+        type1 = lt.String(name='My string!')
+
+        result = json_schema(lt.Object({'foo': type1, 'bar': type1}))
+        assert result['definitions'] == {'MyString': json_schema(type1)}
+
+    def test_definition_name_conflict_resolving(self):
+        type1 = lt.String(name='MyType')
+        type2 = lt.Integer(name='MyType')
+        type3 = lt.Boolean(name='MyType')
+
+        result = json_schema(lt.Object({
+            'field1': type1, 'field2': type2, 'field3': type3,
+            'field4': type1, 'field5': type2, 'field6': type3,
+        }))
+        refs = [
+            '#/definitions/MyType',
+            '#/definitions/MyType1',
+            '#/definitions/MyType2',
+        ]
+        assert result['properties']['field1']['$ref'] in refs
+        assert result['properties']['field2']['$ref'] in refs
+        assert result['properties']['field3']['$ref'] in refs
+        assert len(set(result['properties'][field]['$ref']
+                       for field in ['field1', 'field2', 'field3'])) == 3
+
+    def test_unnamed_types_definition_name_conflict_resolving(self):
+        type1 = lt.String()
+        type2 = lt.Integer()
+        type3 = lt.Integer()
+
+        result = json_schema(lt.Object({
+            'field1': type1, 'field2': type2, 'field3': type3,
+            'field4': type1, 'field5': type2, 'field6': type3,
+        }))
+        refs = [
+            '#/definitions/Type',
+            '#/definitions/Type1',
+            '#/definitions/Type2',
+        ]
+        assert result['properties']['field1']['$ref'] in refs
+        assert result['properties']['field2']['$ref'] in refs
+        assert result['properties']['field3']['$ref'] in refs
+        assert len(set(result['properties'][field]['$ref']
+                       for field in ['field1', 'field2', 'field3'])) == 3

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -117,6 +117,13 @@ class TestJsonSchema:
                                         'bar': lt.Optional(lt.Integer())}))
         assert 'bar' not in result['required']
 
+    def test_object_optional_fields_wrapped_in_other_modifiers(self):
+        result = json_schema(lt.Object({
+            'foo': lt.String(),
+            'bar': lt.DumpOnly(lt.Optional(lt.Integer())),
+        }))
+        assert 'bar' not in result['required']
+
     def test_object_all_optional_fields(self):
         result = json_schema(lt.Object({'foo': lt.Optional(lt.String()),
                                         'bar': lt.Optional(lt.Integer())}))


### PR DESCRIPTION
This patch changes the way type references are handled.
Before if schema has any type references, they are extracted
into "defintions" and replaced with `{'$ref': ...}`. This has a
number of problems:
1. If type reference is used only once, there is no need to 
extract it into definition, it can be just inlined.
2. If type and type references are both present, the raw type
will still be inlined even though it can also be replaced with
reference.

Also, there is a bigger problem of types being used multiple
times throughout schema and inlined in every place (schema
duplication).

This patch fixes that by first traversing the whole schema
tree, finding all duplicates and extracting them as definitions.
This works well for both references and raw types.

Also, there is another fix to properly detect optional types if
they are wrapped with some other modifier type (e.g. DumpOnly
or Transform).

Tweaked dumping of default values (skipping MISSING ones).

Also, add support for generating schema only for load or dump cases
(excluding either DumpOnly or LoadOnly types).