### PR TITLE
Make enums and required fields idempotent

### DIFF
--- a/lollipop_jsonschema/jsonschema.py
+++ b/lollipop_jsonschema/jsonschema.py
@@ -83,7 +83,7 @@ class TypeEncoder(object):
             if not choices:
                 raise ValueError('AnyOf constraints choices does not allow any values')
 
-            js['enum'] = list(schema.dump(choice) for choice in choices)
+            js['enum'] = list(schema.dump(choice) for choice in sorted(choices))
 
         none_of_validators = find_validators(schema, lv.NoneOf)
         if none_of_validators:
@@ -92,7 +92,8 @@ class TypeEncoder(object):
                 choices = choices.union(set(validator.values))
 
             if choices:
-                js['not'] = {'enum': list(schema.dump(choice) for choice in choices)}
+                js['not'] = {'enum': list(
+                    schema.dump(choice) for choice in sorted(choices))}
 
         return js
 
@@ -320,7 +321,7 @@ class ObjectEncoder(TypeEncoder):
 
             required = [
                 field_name
-                for field_name, field in iteritems(schema.fields)
+                for field_name, field in sorted(iteritems(schema.fields))
                 if not is_optional(field.field_type) and field_name in js['properties']
             ]
             if required:
@@ -360,7 +361,7 @@ class DictEncoder(TypeEncoder):
             js['properties'] = properties
         required = [
             k
-            for k, v in iteritems(schema.value_types)
+            for k, v in sorted(iteritems(schema.value_types))
             if not is_optional(v) and k in properties
         ]
         if required:

--- a/tests/test_jsonschema.py
+++ b/tests/test_jsonschema.py
@@ -223,7 +223,7 @@ class TestJsonSchema:
             'foo': {'type': 'string'},
             'bar': {'type': 'integer'},
         }
-        assert sorted(result['required']) == sorted(['foo', 'bar'])
+        assert result['required'] == sorted(['foo', 'bar'])
 
     def test_object_optional_fields(self):
         result = json_schema(lt.Object({'foo': lt.String(),
@@ -300,7 +300,7 @@ class TestJsonSchema:
             'foo': {'type': 'string'},
             'bar': {'type': 'integer'},
         }
-        assert sorted(result['required']) == sorted(['foo', 'bar'])
+        assert result['required'] == sorted(['foo', 'bar'])
 
     def test_variadic_fields_dict_schema(self):
         result = json_schema(lt.Dict(lt.Integer()))
@@ -339,12 +339,12 @@ class TestJsonSchema:
         jschema = json_schema(lt.String(validate=lv.AnyOf(['foo', 'bar', 'baz'])))
         assert len(jschema) == 2
         assert jschema['type'] == 'string'
-        assert sorted(jschema['enum']) == sorted(['foo', 'bar', 'baz'])
+        assert jschema['enum'] == sorted(['foo', 'bar', 'baz'])
 
         jschema = json_schema(lt.Integer(validate=lv.AnyOf([1, 2, 3])))
         assert len(jschema) == 2
         assert jschema['type'] == 'integer'
-        assert sorted(jschema['enum']) == sorted([1, 2, 3])
+        assert jschema['enum'] == sorted([1, 2, 3])
 
     def test_type_with_any_of_validator_values_are_serialized(self):
         MyType = namedtuple('MyType', ['foo', 'bar'])
@@ -355,8 +355,8 @@ class TestJsonSchema:
         )
         jschema = json_schema(MY_TYPE)
 
-        assert sorted(jschema['enum'], key=lambda d: sorted(d.items())) == \
-            [{'foo': 'hello', 'bar': 1}, {'foo': 'goodbye', 'bar': 2}]
+        assert jschema['enum'] == \
+            [{'foo': 'goodbye', 'bar': 2}, {'foo': 'hello', 'bar': 1}]
 
     def test_type_with_multiple_any_of_validators(self):
         jschema = json_schema(
@@ -368,18 +368,18 @@ class TestJsonSchema:
 
         assert len(jschema) == 2
         assert jschema['type'] == 'string'
-        assert sorted(jschema['enum']) == sorted(['bar', 'baz'])
+        assert jschema['enum'] == sorted(['bar', 'baz'])
 
     def test_type_with_none_of_validator_is_dumped_as_not_enum(self):
         jschema = json_schema(lt.String(validate=lv.NoneOf(['foo', 'bar', 'baz'])))
         assert 'not' in jschema
         assert len(jschema['not']) == 1
-        assert sorted(jschema['not']['enum']) == sorted(['foo', 'bar', 'baz'])
+        assert jschema['not']['enum'] == sorted(['foo', 'bar', 'baz'])
 
         jschema = json_schema(lt.Integer(validate=lv.NoneOf([1, 2, 3])))
         assert 'not' in jschema
         assert len(jschema['not']) == 1
-        assert sorted(jschema['not']['enum']) == sorted([1, 2, 3])
+        assert jschema['not']['enum'] == sorted([1, 2, 3])
 
     def test_type_with_none_of_validator_values_are_serialized(self):
         MyType = namedtuple('MyType', ['foo', 'bar'])
@@ -390,8 +390,8 @@ class TestJsonSchema:
         )
         jschema = json_schema(MY_TYPE)
 
-        assert sorted(jschema['not']['enum'], key=lambda d: sorted(d.items())) == \
-            [{'foo': 'hello', 'bar': 1}, {'foo': 'goodbye', 'bar': 2}]
+        assert jschema['not']['enum'] == \
+            [{'foo': 'goodbye', 'bar': 2}, {'foo': 'hello', 'bar': 1}]
 
     def test_type_with_multiple_none_of_validators(self):
         jschema = json_schema(
@@ -401,7 +401,7 @@ class TestJsonSchema:
             ])
         )
 
-        assert sorted(jschema['not']['enum']) == sorted(['foo', 'bar', 'baz', 'bam'])
+        assert jschema['not']['enum'] == sorted(['foo', 'bar', 'baz', 'bam'])
 
     def test_constant(self):
         assert json_schema(lt.Constant('foo')) == {'const': 'foo'}


### PR DESCRIPTION
This patch introduces consistent behaviour of lollipop-jsonschema with "enum" objects and "required" fields.
They will be dumped in a sorted order.