### PR TITLE
Use OpenAPI 3.1.0 compatible format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ lollipop-jsonschema
     :alt: PyPI
 
 Library to convert `Lollipop schema <https://github.com/maximkulkin/lollipop>`_
-to `JSON schema <http://json-schema.org>`_.
+to `JSON schema <http://json-schema.org>`_ in a format compliant with OpenAPI 3.1.0.
 
 Example
 =======

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='lollipop-jsonschema',
-    version='0.8.2',
+    version='0.9.0',
     description=('Library to convert Lollipop schema to JSON schema'),
     long_description=read('README.rst'),
     author='Maxim Kulkin',


### PR DESCRIPTION
This PR updates the format in which JSON schema is rendered to comply with OpenAPI 3.1.0 specification which is a modern replacement for Swagger 2.0 specification. It also properly supports `anyOf`, `oneOf`, `allOf` qualifiers.

https://spec.openapis.org/oas/v3.1.0.html

Changeset is quite small and limited to:

* Top level object that stores reusable schemas is moved from `definitions` into `components/schemas`.
* Rendering for optional fields is converted into a JSON schema compatible format (note that default should comply with the type definition and so we need to explicitly allow for `null` values)
* tuples need to use `prefixItems` not `items` (https://json-schema.org/understanding-json-schema/reference/array)